### PR TITLE
Add pkg-config to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,7 @@
             pkgs.kustomize
 
             customClang
+            pkgs.pkg-config
             pkgs.openssl
           ];
           shellHook = ''


### PR DESCRIPTION
Add pkg-config to the nativebuildinputs in flake.nix in order to be able to use cargo build from the nix development shell.