### PR TITLE
Add state update during init

### DIFF
--- a/src/market_maker.rs
+++ b/src/market_maker.rs
@@ -389,10 +389,10 @@ impl MarketMaker {
 
         // Determine amounts we can put on the book without exceeding the max absolute position size
         // Consider the current position when calculating order amounts
-        let lower_order_amount = (self.max_absolute_position_size - self.cur_position)
-            .clamp(0.0, self.target_liquidity);
-        let upper_order_amount = (self.max_absolute_position_size + self.cur_position)
-            .clamp(0.0, self.target_liquidity);
+        let lower_order_amount =
+            (self.max_absolute_position_size - self.cur_position).clamp(0.0, self.target_liquidity);
+        let upper_order_amount =
+            (self.max_absolute_position_size + self.cur_position).clamp(0.0, self.target_liquidity);
 
         // Determine if we need to cancel the resting order and put a new order up due to deviation
         let lower_change = (lower_order_amount - self.lower_resting.position).abs() > EPSILON


### PR DESCRIPTION
This PR refactors the MarketMaker initialization and adds state update methods.

Key Changes:
Initialization:
Returns a mutable MarketMaker instance.
Updates state with open orders and positions during initialization. 

New Methods:
`update_state`:  Updates state with open orders and positions. 
`fetch_open_orders`: Fetches and updates active and resting orders. 
`fetch_current_position`:  Fetches and updates current user position. These changes ensure the MarketMaker has up-to-date state information on creation.