### PR TITLE
Introduce benchmarking infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +433,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "coins-bip32"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +514,12 @@ dependencies = [
  "sha3",
  "thiserror",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "const-oid"
@@ -591,6 +629,31 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1356,9 +1419,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1410,6 +1473,7 @@ name = "hyperliquid_rust_sdk"
 version = "0.4.0"
 dependencies = [
  "chrono",
+ "divan",
  "env_logger",
  "ethers",
  "futures-util",
@@ -1995,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2113,6 +2177,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
 
 [[package]]
 name = "regex-syntax"
@@ -2770,6 +2840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,18 @@ tokio = {version = "1.29.1", features = ["full"]}
 tokio-tungstenite = {version = "0.20.0", features = ["native-tls"]}
 uuid = {version = "1.6.1", features = ["v4"]}
 gxhash = "3.4.1"
+
+[dev-dependencies]
+divan = "0.1.14"
+
+[profile.release]
+lto = true
+opt-level = 3
+codegen-units = 1
+
+[profile.benches]
+inherits = "release"
+
+[[bench]]
+name = "hashmap_operations"
+harness = false

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ pre-commit run -a
 nix run .#image.copyToDockerDaemon
 ```
 
+## Benchmarking
+
+Add a new file to the `benches` directory and add a new `[[bench]]` section in
+`Cargo.toml`. Then you can invoke the benchmark like so:
+
+```bash
+cargo bench --bench my_benchmark
+```
+
 ## hyperliquid-rust-sdk
 
 SDK for Hyperliquid API trading with Rust.

--- a/benches/hashmap_operations.rs
+++ b/benches/hashmap_operations.rs
@@ -1,0 +1,71 @@
+#![warn(clippy::all, clippy::nursery, clippy::pedantic)]
+
+use gxhash::{HashMap as GxHashMap, HashMapExt};
+use std::hash::Hash;
+
+#[divan::bench(types = [u8, u16, u32, u64], consts = [12, 16, 32], sample_size = 1000, sample_count = 1000)]
+fn insert<T, const N: usize>(bencher: divan::Bencher)
+where
+    T: Copy + Hash + Eq + TryFrom<u64> + std::fmt::Debug + std::marker::Sync,
+    <T as TryFrom<u64>>::Error: std::fmt::Debug,
+{
+    bencher.with_inputs(GxHashMap::default).bench_refs(|map| {
+        for i in 0..N {
+            map.insert(T::try_from(i as u64).unwrap(), i % 2 == 0);
+        }
+    });
+}
+
+#[divan::bench(types = [u8, u16, u32, u64], consts = [12, 16, 32], sample_size = 1000, sample_count = 1000)]
+fn insert_prealloc<T, const N: usize>(bencher: divan::Bencher)
+where
+    T: Copy + Hash + Eq + TryFrom<u64> + std::fmt::Debug + std::marker::Sync,
+    <T as TryFrom<u64>>::Error: std::fmt::Debug,
+{
+    bencher
+        .with_inputs(|| GxHashMap::with_capacity(N))
+        .bench_refs(|map| {
+            for i in 0..N {
+                map.insert(T::try_from(i as u64).unwrap(), i % 2 == 0);
+            }
+        });
+}
+
+#[divan::bench(types = [u8, u16, u32, u64], consts = [12, 16, 32], sample_size = 1000, sample_count = 1000)]
+fn remove<T, const N: usize>(bencher: divan::Bencher)
+where
+    T: Copy + Hash + Eq + TryFrom<u64> + std::marker::Sync,
+    <T as TryFrom<u64>>::Error: std::fmt::Debug,
+{
+    bencher
+        .with_inputs(|| {
+            (0..N)
+                .map(|x| (T::try_from(x as u64).unwrap(), x % 2 == 0))
+                .collect::<GxHashMap<T, bool>>()
+        })
+        .bench_refs(|map| {
+            for i in 0..N {
+                map.remove(&T::try_from(i as u64).unwrap());
+            }
+        });
+}
+
+#[divan::bench(types = [u8, u16, u32, u64], consts = [12, 16, 32], sample_size = 1000, sample_count = 1000)]
+fn contains_key<T, const N: usize>(bencher: divan::Bencher)
+where
+    T: Copy + Hash + Eq + TryFrom<u64> + std::marker::Sync,
+    <T as TryFrom<u64>>::Error: std::fmt::Debug,
+{
+    let map: GxHashMap<T, bool> = (0..N)
+        .map(|x| (T::try_from(x as u64).unwrap(), x % 2 == 0))
+        .collect();
+    bencher.with_inputs(|| map.clone()).bench_refs(|map| {
+        for i in 0..N {
+            map.contains_key(&T::try_from(i as u64).unwrap());
+        }
+    });
+}
+
+fn main() {
+    divan::main();
+}

--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,7 @@
 
             customClang
             pkgs.openssl
+            pkgs.gnuplot
           ];
           shellHook = ''
             # Generate the .pre-commit-config.yaml symlink when entering the

--- a/src/ws/sub_structs.rs
+++ b/src/ws/sub_structs.rs
@@ -43,6 +43,8 @@ pub struct TradeInfo {
     pub start_position: String,
     pub dir: String,
     pub closed_pnl: String,
+    // TODO(aaronmondal): Benchmarks show that we can improve performance by
+    // turning the `oid` into a `u32`. Evaluate whether that's possible.
     pub oid: u64,
     pub cloid: Option<String>,
     pub crossed: bool,


### PR DESCRIPTION
The new setup allows us to create benchmarks in the `benches` directory and invoke them via e.g. `cargo bench --bench hashmap_operations`.

These benchmarks show that we should evaluate whether we can change the `oid` type to `u32` and that initial inserts into the active orders will speed up by ~2.3x if we preallocate the HashMap with an expected capacity.